### PR TITLE
Add export functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "idb": "^7.1.1",
     "jspdf": "^3.0.1",
     "jspdf-autotable": "^5.0.2",
+    "html2canvas": "^1.4.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-redux": "^8.0.5",

--- a/src/html2canvas.d.ts
+++ b/src/html2canvas.d.ts
@@ -1,0 +1,1 @@
+declare module "html2canvas";

--- a/src/pages/EnhancedDashboard.tsx
+++ b/src/pages/EnhancedDashboard.tsx
@@ -1,5 +1,7 @@
-import React, { useState } from "react";
+import React, { useState, useRef } from "react";
 import { useAuth } from "../contexts/AuthContext";
+import jsPDF from "jspdf";
+import html2canvas from "html2canvas";
 // Placeholder for charting library - choose one like Recharts or Chart.js
 // import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';
 
@@ -60,6 +62,8 @@ const EnhancedDashboard: React.FC = () => {
   const complianceExportRef = useRef<HTMLDivElement>(null);
   const incidentExportButtonRef = useRef<HTMLButtonElement>(null);
   const complianceExportButtonRef = useRef<HTMLButtonElement>(null);
+  const incidentChartRef = useRef<HTMLDivElement>(null);
+  const complianceChartRef = useRef<HTMLDivElement>(null);
 
   const [incidentExportOpen, setIncidentExportOpen] = useState(false);
   const [complianceExportOpen, setComplianceExportOpen] = useState(false);
@@ -69,13 +73,47 @@ const EnhancedDashboard: React.FC = () => {
     setExpandedChart((prev) => (prev === chartId ? null : chartId));
   };
 
-  // Export chart data (Placeholder - Needs actual implementation)
-  const exportChart = (chartId: string, format: string): void => {
-    console.log(`Exporting chart ${chartId} in ${format} format`);
-    // TODO: Implement actual export logic (e.g., using html2canvas for PNG, jsPDF for PDF, or data-to-CSV)
-    // Close dropdown after selection
-    if (chartId === "incidents") setIncidentExportOpen(false);
-    if (chartId === "compliance") setComplianceExportOpen(false);
+  const exportChart = async (
+    chartId: "incidents" | "compliance",
+    format: string,
+  ): Promise<void> => {
+    const ref = chartId === "incidents" ? incidentChartRef : complianceChartRef;
+    if (!ref.current) return;
+
+    try {
+      if (format === "png" || format === "pdf") {
+        const canvas = await html2canvas(ref.current);
+        const imgData = canvas.toDataURL("image/png");
+        if (format === "png") {
+          const link = document.createElement("a");
+          link.href = imgData;
+          link.download = `${chartId}-chart.png`;
+          link.click();
+        } else {
+          const pdf = new jsPDF("p", "mm", "a4");
+          const pageWidth = pdf.internal.pageSize.getWidth();
+          const pageHeight = (canvas.height * pageWidth) / canvas.width;
+          pdf.addImage(imgData, "PNG", 0, 0, pageWidth, pageHeight);
+          pdf.save(`${chartId}-chart.pdf`);
+        }
+      } else if (format === "csv") {
+        const metricsEntries = Object.entries(safetyMetrics).map(
+          ([k, v]) => `${k},${v}`,
+        );
+        const csv = ["Metric,Value", ...metricsEntries].join("\n");
+        const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
+        const link = document.createElement("a");
+        link.href = URL.createObjectURL(blob);
+        link.download = `${chartId}-chart.csv`;
+        link.click();
+        URL.revokeObjectURL(link.href);
+      }
+    } catch (error) {
+      console.error("Chart export failed", error);
+    } finally {
+      if (chartId === "incidents") setIncidentExportOpen(false);
+      if (chartId === "compliance") setComplianceExportOpen(false);
+    }
   };
 
   // Close dropdowns when clicking outside
@@ -365,7 +403,11 @@ const EnhancedDashboard: React.FC = () => {
               </button>
             </div>
           </div>
-          <div id="incident-chart-content" className="card-content">
+          <div
+            id="incident-chart-content"
+            className="card-content"
+            ref={incidentChartRef}
+          >
             <div
               className="chart-container"
               aria-label="Incident Trends Bar Chart"
@@ -462,7 +504,11 @@ const EnhancedDashboard: React.FC = () => {
               </button>
             </div>
           </div>
-          <div id="compliance-chart-content" className="card-content">
+          <div
+            id="compliance-chart-content"
+            className="card-content"
+            ref={complianceChartRef}
+          >
             <div
               className="chart-container"
               aria-label="Compliance Metrics Donut Chart"

--- a/src/pages/PerformanceMetrics.tsx
+++ b/src/pages/PerformanceMetrics.tsx
@@ -1,6 +1,8 @@
 import React, { useState, useEffect, useRef, useCallback } from "react";
 import { useToast } from "../contexts/ToastContext";
 import { Chart, registerables } from "chart.js";
+import jsPDF from "jspdf";
+import html2canvas from "html2canvas";
 import { db } from "../utils/firebase"; // Assuming db is exported from firebase.ts
 import {
   collection,
@@ -390,7 +392,7 @@ const PerformanceMetrics: React.FC = () => {
     setShowExportOptions((prev) => !prev);
   };
 
-  const exportMetricsData = (format: "pdf" | "excel"): void => {
+  const exportMetricsData = async (format: "pdf" | "excel"): Promise<void> => {
     if (isExporting) return;
     setIsExporting(true);
     setExportFormat(format);
@@ -400,18 +402,50 @@ const PerformanceMetrics: React.FC = () => {
       title: "Exporting Data",
       message: `Preparing ${format.toUpperCase()} export...`,
     });
-    console.log(`Exporting metrics data in ${format} format`);
-    // TODO: Implement actual export logic (e.g., using jsPDF, SheetJS)
-    setTimeout(() => {
-      setIsExporting(false);
-      setExportFormat(null);
+
+    try {
+      const container = document.querySelector(
+        ".performance-metrics-container",
+      ) as HTMLElement | null;
+      if (!container) throw new Error("Metrics container not found");
+
+      if (format === "pdf") {
+        const canvas = await html2canvas(container);
+        const imgData = canvas.toDataURL("image/png");
+        const pdf = new jsPDF("p", "mm", "a4");
+        const pageWidth = pdf.internal.pageSize.getWidth();
+        const pageHeight = (canvas.height * pageWidth) / canvas.width;
+        pdf.addImage(imgData, "PNG", 0, 0, pageWidth, pageHeight);
+        pdf.save("performance-metrics.pdf");
+      } else {
+        const rows = Object.entries(metrics || {}).map(
+          ([key, val]) => `${key},${val.value}`,
+        );
+        const csv = ["Metric,Value", ...rows].join("\n");
+        const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
+        const link = document.createElement("a");
+        link.href = URL.createObjectURL(blob);
+        link.download = "performance-metrics.csv";
+        link.click();
+        URL.revokeObjectURL(link.href);
+      }
+
       addToast({
         type: "success",
         title: "Export Ready",
         message: `Metrics data export (${format.toUpperCase()}) is ready.`,
       });
-      console.log(`Simulating ${format.toUpperCase()} download...`);
-    }, 1500);
+    } catch (error) {
+      console.error("Metrics export failed", error);
+      addToast({
+        type: "error",
+        title: "Export Failed",
+        message: "Could not export metrics data.",
+      });
+    } finally {
+      setIsExporting(false);
+      setExportFormat(null);
+    }
   };
 
   // --- Focus Management & Keyboard Nav (Keep existing hooks) ---


### PR DESCRIPTION
## Summary
- add html2canvas dependency
- implement export logic for metrics and dashboard charts
- include new type declaration for html2canvas

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: ESLint config missing)*
- `npm run build` *(fails: ts error)*

------
https://chatgpt.com/codex/tasks/task_e_6852401b7b50832aa5d627c32230639b