### PR TITLE
Update services to use import.meta.env

### DIFF
--- a/src/services/aiService.ts
+++ b/src/services/aiService.ts
@@ -1,7 +1,7 @@
 import axios from "axios";
 
 const api = axios.create({
-  baseURL: process.env.REACT_APP_API_URL || "http://localhost:3001/api",
+  baseURL: import.meta.env.VITE_API_URL || "http://localhost:3001/api",
   headers: {
     "Content-Type": "application/json",
   },

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -2,7 +2,7 @@ import axios, { AxiosInstance, AxiosResponse } from "axios";
 
 // Create axios instance with base configuration
 const api: AxiosInstance = axios.create({
-  baseURL: process.env.REACT_APP_API_URL || "http://localhost:3001/api",
+  baseURL: import.meta.env.VITE_API_URL || "http://localhost:3001/api",
   timeout: 10000,
   headers: {
     "Content-Type": "application/json",

--- a/src/services/complianceService.ts
+++ b/src/services/complianceService.ts
@@ -2,7 +2,7 @@ import axios from "axios";
 import { ComplianceItem, ComplianceCategory } from "../models";
 
 const api = axios.create({
-  baseURL: process.env.REACT_APP_API_URL || "http://localhost:3001/api",
+  baseURL: import.meta.env.VITE_API_URL || "http://localhost:3001/api",
   headers: {
     "Content-Type": "application/json",
   },

--- a/src/services/exportService.ts
+++ b/src/services/exportService.ts
@@ -1,7 +1,7 @@
 import axios from "axios";
 
 const api = axios.create({
-  baseURL: process.env.REACT_APP_API_URL || "http://localhost:3001/api",
+  baseURL: import.meta.env.VITE_API_URL || "http://localhost:3001/api",
   headers: {
     "Content-Type": "application/json",
   },

--- a/src/services/inspectionService.ts
+++ b/src/services/inspectionService.ts
@@ -1,7 +1,7 @@
 import axios from "axios";
 
 const api = axios.create({
-  baseURL: process.env.REACT_APP_API_URL || "http://localhost:3001/api",
+  baseURL: import.meta.env.VITE_API_URL || "http://localhost:3001/api",
   headers: {
     "Content-Type": "application/json",
   },

--- a/src/services/riskService.ts
+++ b/src/services/riskService.ts
@@ -92,7 +92,7 @@ export interface RiskReport {
   generatedBy: string;
 }
 
-const API_BASE_URL = process.env.REACT_APP_API_URL || "/api";
+const API_BASE_URL = import.meta.env.VITE_API_URL || "/api";
 
 // Risk matrix configuration
 const RISK_MATRIX: RiskMatrix[] = [


### PR DESCRIPTION
## Summary
- use `import.meta.env.VITE_API_URL` for axios base URLs in service modules
- clean up remaining `process.env.REACT_APP_API_URL` usage

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852404c2338832ab2eb2c8a847ff438