### PR TITLE
Fix CSP meta formatting

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,11 +27,7 @@
 
   <!-- Security Headers -->
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-  <meta http-equiv="Content-Security-Policy"
-    content="default-src 'self';
-             script-src 'self' 'unsafe-inline' https://apis.google.com;
-             connect-src 'self' http://localhost:9099 http://localhost:8080 https://www.googleapis.com;
-             frame-src 'self' http://localhost:9099 https://accounts.google.com https://*.firebaseapp.com https://apis.google.com;">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://apis.google.com; connect-src 'self' http://localhost:9099 http://localhost:8080 https://www.googleapis.com; frame-src 'self' http://localhost:9099 https://accounts.google.com https://*.firebaseapp.com https://apis.google.com;">
 
   <!-- Open Graph / Social Media -->
   <meta property="og:type" content="website" />


### PR DESCRIPTION
## Summary
- format the Content-Security-Policy meta tag as a single line

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685240c116d0832a90c2b8eb628241fd