### PR TITLE
Fix Vite env usage

### DIFF
--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -39,7 +39,7 @@ export const store = configureStore({
         ignoredPaths: ["documents.currentDocument.file"],
       },
     }),
-  devTools: process.env.NODE_ENV !== "production",
+  devTools: import.meta.env.DEV,
 });
 
 export type RootState = ReturnType<typeof store.getState>;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,7 +4,7 @@ import { VitePWA } from "vite-plugin-pwa";
 import path from "path";
 
 // https://vitejs.dev/config/
-export default defineConfig({
+export default defineConfig(({ mode }) => ({
   plugins: [
     react(),
     VitePWA({
@@ -99,7 +99,7 @@ export default defineConfig({
   },
   build: {
     outDir: "dist",
-    sourcemap: process.env.NODE_ENV !== "production",
+    sourcemap: mode !== "production",
     rollupOptions: {
       output: {
         manualChunks: {
@@ -119,6 +119,6 @@ export default defineConfig({
   optimizeDeps: {
     force: true,
   },
-});
+}));
 // This configuration sets up a Vite project with React, PWA support, and various optimizations.
 // It includes service worker caching strategies, asset handling, and a proxy for API requests.


### PR DESCRIPTION
## Summary
- use `import.meta.env.DEV` for Redux devTools
- control sourcemaps via `mode` in Vite config
- convert Vite config to function so mode is available

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685278d9fd08832a88db3175ee456783