### PR TITLE
Allow Auth emulator in CSP

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -26,6 +26,15 @@
             "value": "max-age=31536000"
           }
         ]
+      },
+      {
+        "source": "**",
+        "headers": [
+          {
+            "key": "Content-Security-Policy",
+            "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://apis.google.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https: http://localhost:9099 http://localhost:8080 wss:; frame-src 'self' http://localhost:9099 https://accounts.google.com https://*.firebaseapp.com https://apis.google.com;"
+          }
+        ]
       }
     ]
   },


### PR DESCRIPTION
## Summary
- set a Content Security Policy header in Firebase Hosting

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68527e0c5df0832a94095d820b1153b4