### PR TITLE
Add ESLint flat config

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,22 @@
+const { FlatCompat } = require("@eslint/eslintrc");
+
+const compat = new FlatCompat({
+  baseDirectory: __dirname,
+});
+
+module.exports = [
+  ...compat.config(require("./.eslintrc.cjs")),
+  {
+    ignores: [
+      "coverage/",
+      "dist/",
+      "build/",
+      "node_modules/",
+      "assets/",
+      "*.test.tsx",
+      ".eslintrc.cjs",
+      "sw.js",
+      "workbox-5ffe50d4.js",
+    ],
+  },
+];


### PR DESCRIPTION
## Summary
- add `eslint.config.js` using FlatCompat to reuse existing `.eslintrc.cjs`

## Testing
- `npm run lint` *(fails: Cannot find module '@eslint/eslintrc')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68528277ceb4832ab722444f2c1bbe50