### PR TITLE
Fix user creation and remove placeholder text

### DIFF
--- a/src/pages/DailyReports.tsx
+++ b/src/pages/DailyReports.tsx
@@ -10,6 +10,7 @@ interface Report {
   author: string;
   status: "pending" | "approved" | "rejected";
   type: string;
+  details: string;
 }
 
 const DailyReports: React.FC = () => {
@@ -35,6 +36,7 @@ const DailyReports: React.FC = () => {
           author: "John Smith",
           status: "approved",
           type: "inspection",
+          details: "Inspection completed with no major issues found. Minor housekeeping items noted." ,
         },
         {
           id: "DR-002",
@@ -43,6 +45,7 @@ const DailyReports: React.FC = () => {
           author: "Emma Clark",
           status: "pending",
           type: "equipment",
+          details: "Scheduled maintenance required for hydraulic system." ,
         },
         {
           id: "DR-003",
@@ -51,6 +54,7 @@ const DailyReports: React.FC = () => {
           author: "Michael Johnson",
           status: "approved",
           type: "drill",
+          details: "All staff evacuated in under four minutes. Minor confusion at assembly point." ,
         },
         {
           id: "DR-004",
@@ -59,6 +63,7 @@ const DailyReports: React.FC = () => {
           author: "Sarah Williams",
           status: "rejected",
           type: "inspection",
+          details: "Improper labeling found on several containers. Follow-up required." ,
         },
         {
           id: "DR-005",
@@ -67,6 +72,7 @@ const DailyReports: React.FC = () => {
           author: "David Brown",
           status: "approved",
           type: "compliance",
+          details: "All employees observed wearing required protective equipment." ,
         },
         {
           id: "DR-006",
@@ -75,6 +81,7 @@ const DailyReports: React.FC = () => {
           author: "John Smith",
           status: "approved",
           type: "test",
+          details: "Exit doors functioning correctly and clear of obstructions." ,
         },
         {
           id: "DR-007",
@@ -83,6 +90,7 @@ const DailyReports: React.FC = () => {
           author: "Emma Clark",
           status: "pending",
           type: "maintenance",
+          details: "Awaiting delivery of new bandage supplies." ,
         },
         {
           id: "DR-008",
@@ -91,6 +99,7 @@ const DailyReports: React.FC = () => {
           author: "Michael Johnson",
           status: "approved",
           type: "observation",
+          details: "Oil spill cleaned and area secured." ,
         },
       ];
       setReports(mockReports);
@@ -470,22 +479,7 @@ const DailyReports: React.FC = () => {
 
               <div className="report-content">
                 <h3>Report Content</h3>
-                <p>
-                  This is a placeholder for the actual report content. In a
-                  production environment, this would display the full report
-                  details, including:
-                </p>
-                <ul>
-                  <li>Executive summary</li>
-                  <li>Findings and observations</li>
-                  <li>Compliance status</li>
-                  <li>Recommendations</li>
-                  <li>Action items</li>
-                </ul>
-                <p>
-                  The report would also include any relevant images, charts, or
-                  attachments.
-                </p>
+                <p>{selectedReport.details}</p>
               </div>
             </div>
             <div className="modal-footer">

--- a/src/pages/MonthlyReports.tsx
+++ b/src/pages/MonthlyReports.tsx
@@ -11,6 +11,7 @@ interface Report {
   author: string;
   status: "pending" | "approved" | "rejected";
   type: string;
+  details: string;
 }
 
 // Placeholder for Performance Metrics Data (Consistent with Weekly)
@@ -48,6 +49,7 @@ const MonthlyReports: React.FC = () => {
             author: "Safety Committee",
             status: "pending",
             type: "performance",
+            details: "Compilation of safety metrics for May including incident rates and training completion." ,
           },
           {
             id: "MR-002",
@@ -56,6 +58,7 @@ const MonthlyReports: React.FC = () => {
             author: "Internal Audit",
             status: "pending",
             type: "audit",
+            details: "Audit scheduled with focus on chemical storage areas." ,
           },
           {
             id: "MR-003",
@@ -64,6 +67,7 @@ const MonthlyReports: React.FC = () => {
             author: "Training Dept.",
             status: "approved",
             type: "training",
+            details: "Summary of completed and upcoming training courses." ,
           },
           {
             id: "MR-004",
@@ -72,6 +76,7 @@ const MonthlyReports: React.FC = () => {
             author: "Incident Response Team",
             status: "approved",
             type: "analysis",
+            details: "Breakdown of incidents reported and corrective actions taken." ,
           },
           {
             id: "MR-005",
@@ -80,6 +85,7 @@ const MonthlyReports: React.FC = () => {
             author: "Maintenance Dept.",
             status: "rejected",
             type: "maintenance",
+            details: "Report rejected pending updated service records." ,
           },
           {
             id: "MR-006",
@@ -88,6 +94,7 @@ const MonthlyReports: React.FC = () => {
             author: "Safety Committee",
             status: "approved",
             type: "assessment",
+            details: "Overall risk level reduced compared to previous month." ,
           },
           {
             id: "MR-007",
@@ -96,6 +103,7 @@ const MonthlyReports: React.FC = () => {
             author: "Procurement",
             status: "approved",
             type: "review",
+            details: "Stock levels adequate with minor shortages reported." ,
           },
           {
             id: "MR-008",
@@ -104,6 +112,7 @@ const MonthlyReports: React.FC = () => {
             author: "Admin",
             status: "approved",
             type: "minutes",
+            details: "Summary of meeting topics and assigned action items." ,
           },
         ];
         resolve(mockReports);
@@ -534,22 +543,7 @@ const MonthlyReports: React.FC = () => {
 
               <div className="report-content">
                 <h3>Report Content</h3>
-                <p>
-                  This is a placeholder for the actual report content. In a
-                  production environment, this would display the full report
-                  details, including:
-                </p>
-                <ul>
-                  <li>Key performance indicators (KPIs)</li>
-                  <li>Trend analysis</li>
-                  <li>Compliance summary</li>
-                  <li>Recommendations for improvement</li>
-                  <li>Action plan updates</li>
-                </ul>
-                <p>
-                  The report would also include any relevant charts, graphs, or
-                  attachments.
-                </p>
+                <p>{selectedReport.details}</p>
               </div>
             </div>
             <div className="modal-footer">


### PR DESCRIPTION
## Summary
- update functions to use getFirestore & FieldValue
- create real notification storage
- add report details fields and remove placeholder text
- use report details in Daily/Monthly report modals

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685386a10b44832a803485d6d4f51a9f