### PR TITLE
Fix TS errors and improve offline queue

### DIFF
--- a/src/audit/AuditWorkflow.tsx
+++ b/src/audit/AuditWorkflow.tsx
@@ -305,7 +305,7 @@ const AuditWorkflow: React.FC = () => {
         return;
       }
 
-      let updatedAudit;
+      let updatedAudit: any;
       if (approvalAction === "approve") {
         updatedAudit = await auditService.approveAudit(selectedAudit.id, {
           notes: approvalNotes,

--- a/src/compliance/ComplianceChecklist.tsx
+++ b/src/compliance/ComplianceChecklist.tsx
@@ -97,7 +97,10 @@ const ComplianceChecklist: React.FC = () => {
   const updateItemStatus = async (itemId: string, newStatus: string) => {
     try {
       if (isOffline) {
-        queueAction("updateItemStatus", { itemId, status: newStatus });
+        queueAction({
+          type: "updateItemStatus",
+          payload: { itemId, status: newStatus },
+        });
         // Update UI optimistically
         const updatedItems = items.map((item) =>
           item.id === itemId ? { ...item, status: newStatus } : item,

--- a/src/compliance/OSHAComplianceDashboard.tsx
+++ b/src/compliance/OSHAComplianceDashboard.tsx
@@ -665,10 +665,10 @@ const OSHAComplianceDashboard: React.FC = () => {
                 label="Severity"
                 value={selectedFinding.severity}
                 onChange={(e) =>
-                  setSelectedFinding({
-                    ...selectedFinding,
-                    severity: e.target.value,
-                  })
+                    setSelectedFinding({
+                      ...selectedFinding,
+                      severity: e.target.value as "low" | "medium" | "high" | "critical",
+                    })
                 }
                 fullWidth
                 margin="normal"
@@ -691,10 +691,10 @@ const OSHAComplianceDashboard: React.FC = () => {
                 label="Status"
                 value={selectedFinding.status}
                 onChange={(e) =>
-                  setSelectedFinding({
-                    ...selectedFinding,
-                    status: e.target.value,
-                  })
+                    setSelectedFinding({
+                      ...selectedFinding,
+                      status: e.target.value as "open" | "in-progress" | "closed" | "resolved" | "verified",
+                    })
                 }
                 fullWidth
                 margin="normal"

--- a/src/inspection/InspectionWorkflow.tsx
+++ b/src/inspection/InspectionWorkflow.tsx
@@ -45,10 +45,13 @@ const InspectionWorkflow: React.FC = () => {
 
   const createInspection = async (templateId: string) => {
     try {
-      if (isOffline) {
-        queueAction("createInspection", { templateId });
-        // Update UI optimistically
-        return;
+        if (isOffline) {
+          queueAction({
+            type: "createInspection",
+            payload: { templateId },
+          });
+          // Update UI optimistically
+          return;
       }
 
       const newInspection =
@@ -67,27 +70,31 @@ const InspectionWorkflow: React.FC = () => {
   ) => {
     try {
       if (isOffline) {
-        queueAction("updateInspectionItem", { inspectionId, itemId, data });
+        queueAction({
+          type: "updateInspectionItem",
+          payload: { inspectionId, itemId, data },
+        });
         // Update UI optimistically
         return;
       }
 
-      await inspectionService.updateInspection(inspectionId, {
+      await inspectionService.updateInspectionItem(
+        inspectionId,
         itemId,
-        ...data,
-      });
+        data,
+      );
       // Update local state
-      const updatedInspections = inspections.map((inspection) => {
-        if (inspection.id === inspectionId && inspection.items) {
-          return {
-            ...inspection,
-            items: inspection.items.map((item: InspectionItem) =>
-              item.id === itemId ? { ...item, ...data } : item,
-            ),
-          };
-        }
-        return inspection;
-      });
+        const updatedInspections: Inspection[] = inspections.map((inspection): Inspection => {
+          if (inspection.id === inspectionId && inspection.items) {
+            return {
+              ...inspection,
+              items: inspection.items.map((item: InspectionItem) =>
+                item.id === itemId ? { ...item, ...data } : item,
+              ),
+            };
+          }
+          return inspection;
+        });
 
       setInspections(updatedInspections);
 
@@ -110,23 +117,26 @@ const InspectionWorkflow: React.FC = () => {
 
   const completeInspection = async (inspectionId: string) => {
     try {
-      if (isOffline) {
-        queueAction("completeInspection", { inspectionId });
+        if (isOffline) {
+          queueAction({
+            type: "completeInspection",
+            payload: { inspectionId },
+          });
         // Update UI optimistically
         return;
       }
 
       await inspectionService.completeInspection(inspectionId);
       // Update local state
-      const updatedInspections = inspections.map((inspection) =>
-        inspection.id === inspectionId
-          ? {
-              ...inspection,
-              status: "completed",
-              completedAt: new Date().toISOString(),
-            }
-          : inspection,
-      );
+        const updatedInspections: Inspection[] = inspections.map((inspection): Inspection =>
+          inspection.id === inspectionId
+            ? {
+                ...inspection,
+                status: "completed",
+                completedAt: new Date().toISOString(),
+              }
+            : inspection,
+        );
 
       setInspections(updatedInspections);
 
@@ -148,8 +158,11 @@ const InspectionWorkflow: React.FC = () => {
     finding: Partial<InspectionFinding>,
   ) => {
     try {
-      if (isOffline) {
-        queueAction("addFinding", { inspectionId, itemId, finding });
+        if (isOffline) {
+          queueAction({
+            type: "addFinding",
+            payload: { inspectionId, itemId, finding },
+          });
         // Update UI optimistically
         return;
       }

--- a/src/integration/AIIntegration.tsx
+++ b/src/integration/AIIntegration.tsx
@@ -199,7 +199,7 @@ const AIIntegration: React.FC<AIIntegrationProps> = ({
 
         {result.type === "analysis" ? (
           <Box>
-            {result.sections.map((section: any, index: number) => (
+          {result.sections?.map((section: any, index: number) => (
               <Box key={index} sx={{ mb: 3 }}>
                 <Typography variant="subtitle1" gutterBottom>
                   {section.title}

--- a/src/integration/BackendIntegration.tsx
+++ b/src/integration/BackendIntegration.tsx
@@ -17,7 +17,7 @@ import { selectCurrentTenant } from "../store/slices/tenantSlice";
 
 interface ApiEndpoint {
   name: string;
-  status: "online" | "offline" | "error";
+  status: "online" | "offline" | "degraded" | "error";
   latency: string;
 }
 
@@ -49,11 +49,6 @@ const mockApiService = {
   },
 };
 
-interface ApiEndpoint {
-  name: string;
-  status: "online" | "offline" | "degraded";
-  latency: string;
-}
 
 const BackendIntegration: React.FC = () => {
   const theme = useTheme();
@@ -220,11 +215,11 @@ const BackendIntegration: React.FC = () => {
               <Typography variant="subtitle1" gutterBottom>
                 Role-Based Access Control
               </Typography>
-              <Typography variant="body2" paragraph>
-                Current User: {user?.firstName} {user?.lastName}
-                <br />
-                Roles: {user?.roles?.join(", ") || "None"}
-              </Typography>
+                <Typography variant="body2" paragraph>
+                  Current User: {user?.firstName} {user?.lastName}
+                  <br />
+                  Role: {user?.role || "None"}
+                </Typography>
               <Button variant="outlined" size="small">
                 Validate Permissions
               </Button>

--- a/src/models/Inspection.ts
+++ b/src/models/Inspection.ts
@@ -38,7 +38,7 @@ export interface InspectionFinding {
   location: string;
   evidence: string[];
   correctiveActions: string[];
-  status: "open" | "in-progress" | "resolved" | "verified";
+  status: "open" | "in-progress" | "resolved" | "closed" | "verified";
   assignedTo?: string;
   dueDate?: string;
   itemId?: string;

--- a/src/pages/EnhancedDashboard.tsx
+++ b/src/pages/EnhancedDashboard.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from "react";
+import React, { useState, useRef, useEffect, useCallback } from "react";
 import { logger } from "../utils/logger";
 import { useAuth } from "../contexts/AuthContext";
 import jsPDF from "jspdf";

--- a/src/pages/HelpPage.tsx
+++ b/src/pages/HelpPage.tsx
@@ -296,7 +296,7 @@ const HelpPage: React.FC = () => {
             </Typography>
 
             <AIChatInterface
-              contextType="help"
+              contextType="general"
               placeholder="Ask me anything about SafeSpec OHS..."
               fullHeight={true}
             />

--- a/src/pages/PerformanceMetrics.tsx
+++ b/src/pages/PerformanceMetrics.tsx
@@ -665,30 +665,30 @@ const PerformanceMetrics: React.FC = () => {
                   </p>
                   <p>
                     <strong>Current Value:</strong>{" "}
-                    {metrics && metrics[selectedMetric]
-                      ? formatMetricValue(
-                          selectedMetric,
-                          metrics[selectedMetric].value,
-                        )
-                      : "N/A"}
+                      {metrics && metrics[selectedMetric]
+                        ? formatMetricValue(
+                            selectedMetric,
+                            metrics[selectedMetric]?.value ?? 0,
+                          )
+                        : "N/A"}
                   </p>
                   <p>
                     <strong>Status:</strong>{" "}
-                    {metrics && metrics[selectedMetric]
-                      ? getMetricStatus(
-                          selectedMetric,
-                          metrics[selectedMetric].value,
-                        ).text
-                      : "N/A"}
+                      {metrics && metrics[selectedMetric]
+                        ? getMetricStatus(
+                            selectedMetric,
+                            metrics[selectedMetric]?.value ?? 0,
+                          ).text
+                        : "N/A"}
                   </p>
                   <p>
                     <strong>Trend:</strong>{" "}
-                    {metrics && metrics[selectedMetric]
-                      ? formatTrend(
-                          selectedMetric,
-                          metrics[selectedMetric].trend,
-                        ).text
-                      : "N/A"}
+                      {metrics && metrics[selectedMetric]
+                        ? formatTrend(
+                            selectedMetric,
+                            metrics[selectedMetric]?.trend ?? 0,
+                          ).text
+                        : "N/A"}
                   </p>
                 </div>
                 <div className="chart-container">

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -45,7 +45,7 @@ const ProfilePage: React.FC = () => {
 
   // Profile form state
   const [profileData, setProfileData] = useState({
-    name: user?.name || "",
+    name: user?.displayName || "",
     email: user?.email || "",
     department: "",
     position: "",
@@ -164,7 +164,7 @@ const ProfilePage: React.FC = () => {
                       sx={{ width: 120, height: 120, mb: 2 }}
                       src={user?.avatar}
                     >
-                      {user?.name?.charAt(0)}
+                      {user?.displayName?.charAt(0)}
                     </Avatar>
                     <Button variant="outlined" size="small">
                       Change Photo

--- a/src/services/inspectionService.ts
+++ b/src/services/inspectionService.ts
@@ -1,4 +1,10 @@
 import axios from "axios";
+import {
+  Inspection,
+  InspectionItem,
+  InspectionTemplate,
+  InspectionFinding as Finding,
+} from "../models/Inspection";
 
 const api = axios.create({
   baseURL: import.meta.env.VITE_API_URL || "http://localhost:3001/api",
@@ -7,57 +13,7 @@ const api = axios.create({
   },
 });
 
-export interface Inspection {
-  id: string;
-  title: string;
-  description: string;
-  type: "safety" | "quality" | "environmental" | "compliance";
-  status: "scheduled" | "in-progress" | "completed" | "cancelled";
-  priority: "low" | "medium" | "high" | "critical";
-  assignedTo: string;
-  location: string;
-  scheduledDate: string;
-  completedDate?: string;
-  checklist: InspectionItem[];
-  findings: Finding[];
-  attachments: string[];
-  createdAt: string;
-  updatedAt: string;
-}
-
-export interface InspectionItem {
-  id: string;
-  description: string;
-  category: string;
-  isCompliant: boolean | null;
-  notes?: string;
-  evidence?: string[];
-  severity?: "low" | "medium" | "high" | "critical";
-}
-
-export interface Finding {
-  id: string;
-  description: string;
-  severity: "low" | "medium" | "high" | "critical";
-  category: string;
-  location: string;
-  evidence: string[];
-  correctiveActions: string[];
-  status: "open" | "in-progress" | "resolved" | "verified";
-  assignedTo?: string;
-  dueDate?: string;
-}
-
-export interface InspectionTemplate {
-  id: string;
-  name: string;
-  description: string;
-  type: string;
-  checklist: Omit<
-    InspectionItem,
-    "id" | "isCompliant" | "notes" | "evidence"
-  >[];
-}
+// reuse types from models
 
 export const inspectionService = {
   async getInspections(
@@ -97,6 +53,18 @@ export const inspectionService = {
     updates: Partial<Inspection>,
   ): Promise<Inspection> {
     const response = await api.put(`/inspections/${id}`, updates);
+    return response.data;
+  },
+
+  async updateInspectionItem(
+    inspectionId: string,
+    itemId: string,
+    updates: Partial<InspectionItem>,
+  ): Promise<InspectionItem> {
+    const response = await api.put(
+      `/inspections/${inspectionId}/items/${itemId}`,
+      updates,
+    );
     return response.data;
   },
 

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,11 +1,13 @@
+const isDev = (import.meta.env as any).DEV;
+
 export const logger = {
   info: (...args: unknown[]): void => {
-    if (import.meta.env.DEV) {
+    if (isDev) {
       console.log(...args);
     }
   },
   warn: (...args: unknown[]): void => {
-    if (import.meta.env.DEV) {
+    if (isDev) {
       console.warn(...args);
     }
   },


### PR DESCRIPTION
## Summary
- add `updateInspectionItem` service method and update workflow
- use optional chaining in AI results rendering
- unify `ApiEndpoint` interface and fix role display
- import missing React hooks
- handle metric optional values safely
- add offline queue action payloads
- correct property names and enums
- streamline logger env detection

## Testing
- `npm test`
- `npm run lint`
- `npx tsc -b` *(fails: TS errors remain)*

------
https://chatgpt.com/codex/tasks/task_e_6853c0eee488832aa7b49a84317c17ca