### PR TITLE
Add full document management pages

### DIFF
--- a/src/pages/DocumentDetailsPage.tsx
+++ b/src/pages/DocumentDetailsPage.tsx
@@ -1,22 +1,122 @@
-import React from "react";
-import { Container, Typography, Paper, Box } from "@mui/material";
-import { useParams } from "react-router-dom";
+import React, { useEffect } from "react";
+import {
+  Container,
+  Typography,
+  Paper,
+  Box,
+  Button,
+  CircularProgress,
+  Alert,
+} from "@mui/material";
+import { Download as DownloadIcon, Edit as EditIcon } from "@mui/icons-material";
+import { useParams, useNavigate } from "react-router-dom";
+import { useAppDispatch, useAppSelector } from "@store/index";
+import {
+  fetchDocumentById,
+  selectCurrentDocument,
+  selectDocumentsLoading,
+  selectDocumentsError,
+} from "@store/slices/documentSlice";
 
 const DocumentDetailsPage: React.FC = () => {
   const { id } = useParams<{ id: string }>();
+  const dispatch = useAppDispatch();
+  const navigate = useNavigate();
+
+  const doc = useAppSelector(selectCurrentDocument);
+  const loading = useAppSelector(selectDocumentsLoading);
+  const error = useAppSelector(selectDocumentsError);
+
+  useEffect(() => {
+    if (id) {
+      dispatch(fetchDocumentById(id));
+    }
+  }, [dispatch, id]);
+
+  const handleEdit = () => {
+    navigate(`/documents/${id}/edit`);
+  };
+
+  const handleDownload = () => {
+    if (doc?.fileUrl) {
+      const link = document.createElement("a");
+      link.href = doc.fileUrl;
+      link.download = doc.title;
+      link.click();
+    }
+  };
+
+  if (loading && !doc) {
+    return (
+      <Container maxWidth="md">
+        <Box sx={{ display: "flex", justifyContent: "center", py: 4 }}>
+          <CircularProgress />
+        </Box>
+      </Container>
+    );
+  }
+
+  if (error) {
+    return (
+      <Container maxWidth="md">
+        <Alert severity="error" sx={{ mt: 2 }}>
+          {error}
+        </Alert>
+      </Container>
+    );
+  }
+
+  if (!doc) {
+    return (
+      <Container maxWidth="md">
+        <Alert severity="warning" sx={{ mt: 2 }}>
+          Document not found
+        </Alert>
+      </Container>
+    );
+  }
 
   return (
-    <Container maxWidth="lg">
+    <Container maxWidth="md">
       <Box sx={{ mt: 4, mb: 4 }}>
         <Typography variant="h4" component="h1" gutterBottom>
-          Document Details
+          {doc.title}
         </Typography>
-
         <Paper sx={{ p: 3 }}>
-          <Typography variant="body1">Document details for ID: {id}</Typography>
-          <Typography variant="body2" sx={{ mt: 2 }}>
-            Document details component will be implemented here.
+          <Typography variant="subtitle1" gutterBottom>
+            Description
           </Typography>
+          <Typography variant="body1" paragraph>
+            {doc.description || "No description provided."}
+          </Typography>
+          <Typography variant="subtitle1" gutterBottom>
+            Category
+          </Typography>
+          <Typography variant="body1" paragraph>{doc.category}</Typography>
+          <Typography variant="subtitle1" gutterBottom>
+            Status
+          </Typography>
+          <Typography variant="body1" paragraph>
+            {doc.status.replace("_", " ")}
+          </Typography>
+          {doc.fileUrl && (
+            <Button
+              variant="contained"
+              sx={{ mt: 2, mr: 2 }}
+              startIcon={<DownloadIcon />}
+               onClick={handleDownload}
+            >
+              Download File
+            </Button>
+          )}
+          <Button
+            variant="outlined"
+            sx={{ mt: 2 }}
+            startIcon={<EditIcon />}
+            onClick={handleEdit}
+          >
+            Edit
+          </Button>
         </Paper>
       </Box>
     </Container>

--- a/src/pages/DocumentFormPage.tsx
+++ b/src/pages/DocumentFormPage.tsx
@@ -1,24 +1,53 @@
-import React from "react";
-import { Container, Typography, Paper, Box } from "@mui/material";
+import React, { useEffect } from "react";
+import { Container, Typography, Box, CircularProgress } from "@mui/material";
 import { useParams, useNavigate } from "react-router-dom";
+import DocumentUploader from "@components/documents/DocumentUploader";
+import { useAppDispatch, useAppSelector } from "@store/index";
+import {
+  fetchDocumentById,
+  selectCurrentDocument,
+  selectDocumentsLoading,
+  clearCurrentDocument,
+} from "@store/slices/documentSlice";
 
 const DocumentFormPage: React.FC = () => {
   const { id } = useParams<{ id?: string }>();
   const navigate = useNavigate();
+  const dispatch = useAppDispatch();
   const isEditing = !!id;
 
+  const document = useAppSelector(selectCurrentDocument);
+  const loading = useAppSelector(selectDocumentsLoading);
+
+  useEffect(() => {
+    if (isEditing && id) {
+      dispatch(fetchDocumentById(id));
+    } else {
+      dispatch(clearCurrentDocument());
+    }
+  }, [dispatch, id, isEditing]);
+
+  const handleSaved = (doc: any) => {
+    navigate(`/documents/${doc.id}`);
+  };
+
+  if (isEditing && loading && !document) {
+    return (
+      <Container maxWidth="md">
+        <Box sx={{ display: "flex", justifyContent: "center", py: 4 }}>
+          <CircularProgress />
+        </Box>
+      </Container>
+    );
+  }
+
   return (
-    <Container maxWidth="lg">
+    <Container maxWidth="md">
       <Box sx={{ mt: 4, mb: 4 }}>
         <Typography variant="h4" component="h1" gutterBottom>
-          {isEditing ? "Edit Document" : "Create New Document"}
+          {isEditing ? "Edit Document" : "Upload New Document"}
         </Typography>
-
-        <Paper sx={{ p: 3 }}>
-          <Typography variant="body1">
-            Document form component will be implemented here.
-          </Typography>
-        </Paper>
+        <DocumentUploader document={isEditing ? document : null} onDocumentCreated={handleSaved} />
       </Box>
     </Container>
   );


### PR DESCRIPTION
## Summary
- enhance `DocumentUploader` to handle editing existing documents
- implement `DocumentFormPage` with loader and save redirect
- implement `DocumentDetailsPage` to view and download documents

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6854e6325720832ab2a3b3fc485eda57